### PR TITLE
Bump jackson-databind to 3.2.1 in blaise-json

### DIFF
--- a/blaise-json/pom.xml
+++ b/blaise-json/pom.xml
@@ -57,7 +57,7 @@
         <dependency>
             <groupId>tools.jackson.core</groupId>
             <artifactId>jackson-databind</artifactId>
-            <version>3.1.3</version>
+            <version>3.2.1</version>
         </dependency>
         <dependency>
             <groupId>junit</groupId>


### PR DESCRIPTION
## Summary
- Bumps `tools.jackson.core:jackson-databind` in blaise-json from 3.1.3 to 3.2.1 (latest minor)
- Fixes 9 open Dependabot security alerts (2 high, 7 medium) against jackson-databind < 3.1.4/3.1.5; 3.2.1 is newer than all patched versions
- Supersedes #267, which only proposed the minimal patch bump to 3.1.5

Refs #268

## Test plan
- [x] `mvn test` in blaise-json: 36 tests, 0 failures, 0 errors
- [x] No downstream blaisemath module pins blaise-json, so no further module needs re-testing